### PR TITLE
Allow newer versions of XHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/hhvm/xhp-js",
   "license": ["BSD-3-Clause"],
   "require": {
-    "facebook/xhp-lib": "~2.2.0",
+    "facebook/xhp-lib": "^2.2.0",
     "hhvm": "~3.6"
   },
   "autoload": {


### PR DESCRIPTION
XHP is now up to 2.3.something, so support that with the version constraint.

See [the docs](https://getcomposer.org/doc/articles/versions.md#tilde) for the difference between a tilde and a caret.
